### PR TITLE
chore: use github.api_url as default githubBaseUrl

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ inputs:
   githubBaseUrl:
     description: "If you use Github Enterprise, you can set this to the URL of your server (e.g. https://github.myorg.com/api/v3)"
     required: false
+    default: '${{ github.api_url }}'
   ignoreLabels:
     description: "If the PR contains one of these labels (newline delimited), the validation is skipped. If you want to rerun the validation when labels change, you might want to use the `labeled` and `unlabeled` event triggers in your workflow."
     required: false


### PR DESCRIPTION
Currently the GitHub API URL has to be set manually.
This will change that you do not longer need to set the input on a GHE instance.

This change uses the [github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).