### PR TITLE
chore: enable GH actions when forking

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,7 +11,8 @@ If e.g. environment parameters are changed, the action should be tested end-to-e
 To do this, please follow this process:
 
 1. Fork the repo.
-2. Create a PR in **your own repo**.
-3. The "Lint PR title preview (current branch)" workflow will run the new version and will help you validate the change.
-4. Create a PR to this repo with the changes. In this case the preview workflow will fail, but we'll know that it works since you've tested it in the fork. Please include a include a link to a workflow where you've tested the current state of this pull request.
-5. Don't run `npm run build` to update the `dist` folder as it will be generated on CI during the build
+2. Enable GitHub Actions in your repository.
+3. Create a PR in **your own repo**.
+4. The "Lint PR title preview (current branch)" workflow will run the new version and will help you validate the change.
+5. Create a PR to this repo with the changes. In this case the preview workflow will fail, but we'll know that it works since you've tested it in the fork. Please include a include a link to a workflow where you've tested the current state of this pull request.
+6. Don't run `npm run build` to update the `dist` folder as it will be generated on CI during the build

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,8 +11,8 @@ If e.g. environment parameters are changed, the action should be tested end-to-e
 To do this, please follow this process:
 
 1. Fork the repo.
-2. Enable GitHub Actions in your repository.
-3. Create a PR in **your own repo**.
-4. The "Lint PR title preview (current branch)" workflow will run the new version and will help you validate the change.
-5. Create a PR to this repo with the changes. In this case the preview workflow will fail, but we'll know that it works since you've tested it in the fork. Please include a include a link to a workflow where you've tested the current state of this pull request.
-6. Don't run `npm run build` to update the `dist` folder as it will be generated on CI during the build
+1. Enable GitHub Actions in your repository.
+1. Create a PR in **your own repo**.
+1. The "Lint PR title preview (current branch)" workflow will run the new version and will help you validate the change.
+1. Create a PR to this repo with the changes. In this case the preview workflow will fail, but we'll know that it works since you've tested it in the fork. Please include a include a link to a workflow where you've tested the current state of this pull request.
+1. Don't run `npm run build` to update the `dist` folder as it will be generated on CI during the build


### PR DESCRIPTION
Add instruction to enable GH Actions before creating PR to ensure workflow triggers.
Per default the workflows are NOT enabled!